### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,74 +2,122 @@
 
 [nelua.io](https://nelua.io/)
 
-# Nelua Programming Language
-
 [![Build Status](https://travis-ci.org/edubart/nelua-lang.svg?branch=master)](https://travis-ci.org/edubart/nelua-lang)
 [![Coverage Status](https://coveralls.io/repos/github/edubart/nelua-lang/badge.svg?branch=master)](https://coveralls.io/github/edubart/nelua-lang?branch=master)
 [![Discord](https://img.shields.io/discord/680417078959800322.svg)](https://discord.gg/7aaGeG7)
 [![Try on Repl.it](https://repl.it/badge/github/edubart/nelua-lang)](https://repl.it/@edubart/nelua-lang#examples/replit.lua)
 
-Nelua is a minimal, simple, efficient, statically typed, compiled, meta programmable,
-safe and extensible systems programming language with a Lua flavor.
-It uses ahead of time compilation to compile to native code.
-Nelua stands for *Native Extensible Lua*.
+Nelua (stands for **N**ative **E**xtensible **Lua**) is a minimal,
+statically-typed and meta-programmable systems programming language heavily
+inspired by Lua, which compiles to C.
 
-**NOTE: The language is in development and in alpha state.**
+**Note:** The language is in alpha state and still evolving.
+
+## Quick start
+
+- For basic information, first steps and how to install Nelua, start at the
+  [Tutorial](https://nelua.io/tutorial/).
+- Read the [Overview](https://nelua.io/overview/) for a tour of the language's
+  syntax, features and usage.
+- Check out the [examples](./examples) folder for small programs written in
+  Nelua.
+
+After installing, you might want to check out the featured example: a Snake
+game leveraging the famous [SDL2](https://www.libsdl.org) game engine.
+
+``` nelua examples/snakesdl.nelua ```
+
+Last, but not least, feel free to give feedback and ask questions over at the
+[Discord server](https://discord.gg/7aaGeG7).
+
+## Benchmarks
+
+The benchmark suite lives in the [benchmark](./benchmark) folder and can be
+ran with `make benchmark`. It compares:
+  
+- Pure C implementations
+- C-compiled Nelua implementations
+- Lua-compiled Nelua implementations
+
+Master branch benchmark runs are recorded through
+[Github Actions](https://github.com/edubart/nelua-lang/actions).
+
+### Exemplary measurement reports
+
+- LuaJIT 2.1.0-beta3
+- GCC 9.3.0 `-O3 -fno-plt -march=native -flto`
+- Lua 5.3.5
+- CPU Intel Core i7-3770K CPU @ 3.50GHz
+- Arch Linux
+
+|    benchmark |  lua 5.3 | luajit 2.1 |    nelua |        c |
+|--------------|----------|------------|----------|----------|
+|    ackermann | 2448.2 ms | 145.2 ms  |  47.8 ms |  47.4 ms |
+|    fibonacci  | 2612.4 ms | 951.7 ms  | 279.9 ms | 280.9 ms |
+|       mandel | 2549.6 ms |  97.0 ms  |  88.5 ms |  88.2 ms |
+|        sieve | 1240.4 ms | 265.3 ms  |  88.7 ms |  60.1 ms |
+|     heapsort | 2602.1 ms | 274.0 ms  | 170.9 ms | 127.5 ms |
+
+*NOTE*: Nelua could match C speed if all benchmarks were coded using optimized structures,
+but to make fair comparisons with Lua/LuaJIT they were coded in Lua style
+(using sequence tables and a garbage collector).
 
 ## About
 
 Nelua is a [systems programming language](https://en.wikipedia.org/wiki/System_programming_language)
-for performance sensitive applications where
-[Lua](https://en.wikipedia.org/wiki/Lua_(programming_language))
-would not be efficient, like operational systems, real-time applications and game engines.
-It has syntax and semantics similar to Lua,
-but is designed to be able to work free from a Lua interpreter,
-instead it takes advantage of
-[ahead of time compilation](https://en.wikipedia.org/wiki/Ahead-of-time_compilation).
-When coding using Nelua idioms such as type notations, records, arrays,
-manual memory management, pointers the performance should be efficient as C.
-But when using Lua idioms such as tables, metatables and untyped variables the compiler
-uses a runtime library to provide the dynamic functionality.
+for performance-sensitive applications where [Lua](https://en.wikipedia.org/wiki/Lua_(programming_language))
+would not be efficient, such as operating systems, real-time applications and
+game engines. While it has syntax and semantics similar to Lua, it primarily
+focuses on generating efficient C code and provide support for
+highly-optimizable low-level programming. Using Nelua idioms such as records,
+arrays, manual memory management and pointers should result in performance as
+efficient as pure C; on the other hand, when using Lua idioms such as tables,
+metatables and untyped variables, the compiler will bake a runtime library for
+this sort of dynamic functionality into the program, which could incur some
+runtime overhead.
 
-Nelua can do compile-time [meta programming](https://en.wikipedia.org/wiki/Metaprogramming)
-because it has a Lua preprocessor
-capable to cooperate with the compiler as it compiles,
-this is only possible because the compiler is fully made in Lua
-and is fully accessible or modifiable by the preprocessor on the fly.
-Therefore it's possible to implement higher constructs such as classes,
+
+Nelua can do [meta programming](https://en.wikipedia.org/wiki/Metaprogramming)
+at compile time through preprocessor constructs written in Lua; since the
+compiler itself is also written in Lua, it means that user-provided
+preprocessor code can interact at any point with the compiler's internals and
+the source code's [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
+Such system allows for ad-hoc implementation of high level constructs such as
+[classes](https://en.wikipedia.org/wiki/Class_(computer_programming)),
 [generics](https://en.wikipedia.org/wiki/Generic_programming) and
-[polymorphism](https://en.wikipedia.org/wiki/Polymorphism_(computer_science))
-at compile time without having to make them into the language specification,
-thus keeping the language simpler and compact.
-For example in Lua classes don't exist but you can implement yourself using metatables,
-in Nelua they don't exist neither but you can implement more efficiently at compile time
-by meta programming or at runtime just like in Lua.
+[polymorphism](https://en.wikipedia.org/wiki/Polymorphism_(computer_science)),
+all without having to add them into the core specification, thus keeping the
+language simple, extensible and compact. The same way that Lua's
+object-oriented patterns are not built into the language, but can be
+nonetheless achieved through [metatables](https://webserver2.tecgraf.puc-rio.br/lua/local/pil/13.html),
+in Nelua you could yourself implement a similar functionality which is fully
+decided at compile time or dynamically dispatched at runtime.
 
 Nelua can do [extensible programming](https://en.wikipedia.org/wiki/Extensible_programming)
-as the programmer may add extensions to the language such as new grammars, [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) definitions, semantics, type checkers, code
-generation and behaviors to the compiler at compile time via the preprocessor.
+as the programmer may add extensions to the language such as new grammars,
+[AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) definitions,
+semantics, type checkers, code generation and behaviors to the compiler at
+compile time via the preprocessor.
 
-Nelua has two choices for
-[memory management](https://en.wikipedia.org/wiki/Memory_management),
-it's the developer choice to use
-[garbage collection](https://en.wikipedia.org/wiki/Garbage_collection_(computer_science))
-or
-[manual memory management](https://en.wikipedia.org/wiki/Manual_memory_management)
-depending on his use case.
+Nelua provides support for both [garbage-collected](https://en.wikipedia.org/wiki/Garbage_collection_(computer_science))
+and [manual](https://en.wikipedia.org/wiki/Manual_memory_management)
+memory management in a way that the developer can easily choose between either
+for each allocation in the program.
 
-Nelua compiles to [C](https://en.wikipedia.org/wiki/C_(programming_language)) first
-then to the target [native code](https://en.wikipedia.org/wiki/Machine_code),
-this way existing C libraries and APIs can be reused and new C libraries can be created.
-Any platform that a C99 compiler targets the language is capable of targeting so
-the language can take advantage of highly optimized compilers such as
-[GCC](https://en.wikipedia.org/wiki/GNU_Compiler_Collection) and
-[Clang](https://en.wikipedia.org/wiki/Clang),
-thus generating very efficient native code.
+Nelua first compiles to
+[C](https://en.wikipedia.org/wiki/C_(programming_language), then it executes a
+C compiler to produce [native code](https://en.wikipedia.org/wiki/Machine_code).
+This way existing C code and libraries can be leveraged and new C libraries can
+be created. Another benefit is that Nelua can reach the same target platforms
+as C99 compilers, such [GCC](https://en.wikipedia.org/wiki/GNU_Compiler_Collection)
+or [Clang](https://en.wikipedia.org/wiki/Clang), while also enjoying
+state-of-the-art compiler optimizations provided by them.
 
-The motivation of the language is to replace C/C++ part of projects that uses
-Lua today with a language that have syntax and semantics similar to Lua, but
-without loosing performance or the ability to go low level. Therefore unifying the
-syntax and semantics across both compiled and dynamic language.
+The initial motivation for its creation was to replace C/C++ parts of projects
+which currently uses Lua with a language that has syntax and semantics similar
+to Lua, but allows for fine-grained performance optimizations and does not lose
+the ability to go low level, therefore unifying the syntax and semantics across
+both compiled and dynamic languages.
 
 ## Goals
 
@@ -100,83 +148,6 @@ syntax and semantics across both compiled and dynamic language.
 * We want to extended the language features by meta programming or modding the compiler.
 * We want to code with or without garbage collection depending on our use case.
 * We want to abuse of static dispatch instead of dynamic dispatch to gain performance and correctness.
-
-## Learning
-
-More details about the language can be read on the following links:
-* Check out the language [overview](https://nelua.io/overview/)
-to get a quick view of the language syntax, features and usage.
-* Check out the language [tutorial](https://nelua.io/tutorial/)
-for learning the basics.
-* Join the language [discord chat](https://discord.gg/7aaGeG7)
-in case you have questions or need help.
-
-## Quick Installation
-
-In a system with build tools and a C compiler do:
-
-```bash
-git clone https://github.com/edubart/nelua-lang.git && cd nelua-lang
-make
-sudo make install
-```
-
-The Nelua compiler should be available in `/usr/local/bin/nelua`,
-now run the hello world example:
-
-```
-nelua examples/helloworld.nelua
-```
-
-For complete instructions on how to install see the [installing tutorial](https://nelua.io/installing/).
-
-## Examples
-
-The folder [examples](https://github.com/edubart/nelua-lang/tree/master/examples)
-contains some examples in Nelua, including some games,
-most of the examples currently work only with the default C generator backend.
-
-To run the Snake demo for example run:
-
-```shell
-nelua examples/snakesdl.nelua
-```
-
-## Benchmarks
-
-Some benchmarks can be found in `benchmarks` folder, it contains nelua benchmarks
-and pure C benchmark as reference. The Lua code of the benchmarks are generated
-by nelua compiler, as it can compile to Lua too.
-
-The benchmarks can be run with `make benchmark`, this is my last results:
-
-|    benchmark |  lua 5.3 | luajit 2.1 |    nelua |        c |
-|--------------|----------|------------|----------|----------|
-|    ackermann | 2448.2 ms | 145.2 ms  |  47.8 ms |  47.4 ms |
-|    fibonacci | 2612.4 ms | 951.7 ms  | 279.9 ms | 280.9 ms |
-|       mandel | 2549.6 ms |  97.0 ms  |  88.5 ms |  88.2 ms |
-|        sieve | 1240.4 ms | 265.3 ms  |  88.7 ms |  60.1 ms |
-|     heapsort | 2602.1 ms | 274.0 ms  | 170.9 ms | 127.5 ms |
-
-*NOTE*: Nelua can match C speed if all benchmarks were coded using optimized structures,
-however to make the benchmarks comparisons fair with Lua/LuaJIT they were coded in Lua style
-(using sequence tables and a garbage collector).
-
-Environment that this benchmark was run:
-LuaJIT 2.1.0-beta3,
-GCC 9.3.0,
-Lua 5.3.5,
-CPU Intel Core i7-3770K CPU @ 3.50GHz,
-OS ArchLinux
-CFLAGS `-O3 -fno-plt -march=native -flto`
-
-Previous test runs on the master branch can be seen in the
-[github's actions tab](https://github.com/edubart/nelua-lang/actions).
-
-## Roadmap
-
-Language planned features and history of accomplished features can be seen
-in the [github's projects tab](https://github.com/edubart/nelua-lang/projects).
 
 ## Contributing
 


### PR DESCRIPTION
You can read this new README at https://github.com/resolritter/nelua-lang/blob/patch-1/README.md

# Rationality
  - The site should be the source of truth for documentation; the README should only reference it to avoid duplication of information
  - The README should not have technical or in-depth documentation upfront, but instead quick information and links to other places
      - Newcomers looking for a new language want to be able to read the examples and the syntax ASAP
      - Experienced programmers want to see the code and what the language can do ASAP
      - Sections which relate to those interests should be merged

# Quick installation
  - The installation is already linked in the Tutorial, so it doesn't need to be written in the README, as it can get outdated and/or misleading with time

# About, Roadmap, etc

- The description here should be included in the official website as well. Maybe the website code could generate the HTML from this README markdown.