### PR TITLE
Fix building on Mac/Darwin

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -36,6 +36,10 @@ ifeq ($(SYS), Linux)
 else ifeq ($(SYS), Windows)
 	CC=x86_64-w64-mingw32-gcc
 	EXE=nelua-lua.exe
+else ifeq ($(SYS), Darwin)
+	CC=clang
+	LDFLAGS=
+	DEFS+=-DLUA_USE_POSIX
 else # probably POSIX
 	CC=cc
 	LDFLAGS+=-Wl,-E

--- a/src/sys.c
+++ b/src/sys.c
@@ -23,6 +23,8 @@
     #warning "falling back to microsecond gettimeofday()"
     #include <sys/time.h>
   #endif
+  #elif defined(__APPLE__)
+    #include <sys/time.h>
   #endif
 #endif
 


### PR DESCRIPTION
Hi there, very cool project!

I'm running macOS Catalina and am not able to compile Nelua using just `make`:

~~~
$ make
cc -o nelua-lua \
		-DNDEBUG -DLUA_COMPAT_5_3 -DLUAI_MAXCSTACK=16384 -DLUA_USE_RPMALLOC -DENABLE_GLOBAL_CACHE=0 -DBUILD_DYNAMIC_LINK LUA_USE_POSIX \
		-Ilua \
		-Wall -O2 -fno-plt -fno-stack-protector -flto  \
		-s -Wl,-E  \
		lua/onelua.c rpmalloc/rpmalloc.c lfs.c sys.c hasher.c lpeglabel/*.c  \
		-lm 
clang: error: no such file or directory: 'LUA_USE_POSIX'
make[1]: *** [nelua-lua] Error 1
make: *** [nelua-lua] Error 2
~~~

There seem to be a few issues:

- Need `-DLUA_USE_POSIX`, not just `LUA_USE_POSIX`.
- Need `#include <sys/time.h>` but `_POSIX_TIMERS` isn't `> 0`.
- Mac's (LLVM's) `ld` is different from GNU's and doesn't support `-s` or `-E`.

This PR just checks for Darwin/Mac and sets the right flags. So far everything seems to work for me, but I'm no expert.
