### PR TITLE
Set LUA_USE_MACOSX on macOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,7 +39,7 @@ else ifeq ($(SYS), Windows)
 else ifeq ($(SYS), Darwin)
 	CC=clang
 	LDFLAGS=
-	DEFS+=-DLUA_USE_POSIX
+	DEFS+=-DLUA_USE_MACOSX
 else # probably POSIX
 	CC=cc
 	LDFLAGS+=-Wl,-E


### PR DESCRIPTION
Continuation of #22. Need to set this on macOS to enable dynamic library loading. Uncovered while trying to get `make test` to succeed.