### PR TITLE
Multiple switch cases with the same block. Additional `do` syntax.

### DIFF
--- a/nelua/analyzer.lua
+++ b/nelua/analyzer.lua
@@ -1369,13 +1369,17 @@ function visitors.Switch(context, node)
   end
   for i=1,#caseparts do
     local casepart = caseparts[i]
-    local casenode, blocknode = casepart[1], casepart[2]
-    context:traverse_node(casenode)
-    if not (casenode.attr.type and casenode.attr.type.is_integral and
-           (casenode.attr.comptime or casenode.attr.cimport)) then
-      casenode:raisef("`case` statement must evaluate to a compile time integral value")
+
+    for parti=1, #casepart-1 do
+      local casenode = casepart[parti]
+      context:traverse_node(casenode)
+      if not (casenode.attr.type and casenode.attr.type.is_integral and
+             (casenode.attr.comptime or casenode.attr.cimport)) then
+        casenode:raisef("`case` statement must evaluate to a compile time integral value")
+      end
     end
-    context:traverse_node(blocknode)
+
+    context:traverse_node(casepart[#casepart])
   end
   if elsenode then
     context:traverse_node(elsenode)

--- a/nelua/astdefs.lua
+++ b/nelua/astdefs.lua
@@ -227,7 +227,7 @@ astbuilder:register('BinaryOp', {
 -- nelua extesions to lua
 astbuilder:register('Switch', {
   ntypes.Node, -- switch expr
-  stypes.array_of(stypes.shape{ntypes.Node, ntypes.Block}), -- case list {expr, block}
+  stypes.array_of(stypes.shape{ stypes.array_of(ntypes.Node), ntypes.Block}), -- case list {expr list, block}
   ntypes.Block:is_optional() -- else block
 })
 

--- a/nelua/cgenerator.lua
+++ b/nelua/cgenerator.lua
@@ -937,9 +937,11 @@ function visitors.Switch(_, node, emitter)
   emitter:add_indent_ln("switch(", valnode, ") {")
   emitter:inc_indent()
   for _,casepart in ipairs(caseparts) do
-    local casenode, blocknode = casepart[1], casepart[2]
-    emitter:add_indent_ln("case ", casenode, ': {')
-    emitter:add(blocknode)
+    for i=1, #casepart-2 do
+      emitter:add_indent_ln("case ", casepart[i], ":")
+    end
+    emitter:add_indent_ln("case ", casepart[#casepart-1], ': {') -- last case
+    emitter:add(casepart[#casepart]) -- block
     emitter:inc_indent() emitter:add_indent_ln('break;') emitter:dec_indent()
     emitter:add_indent_ln("}")
   end

--- a/nelua/syntaxdefs.lua
+++ b/nelua/syntaxdefs.lua
@@ -349,9 +349,9 @@ local function get_parser()
   ]], nil, true)
 
   grammar:add_group_peg('stat', 'switch', [[
-    ({} %SWITCH -> 'Switch' eexpr
+    ({} %SWITCH -> 'Switch' eexpr %DO
       {|(
-        ({| %CASE eexpr eTHEN block |})+ / %{ExpectedCase})
+        ({| %CASE eexpr (%COMMA expr)* eTHEN block |})+ / %{ExpectedCase})
       |}
       (%ELSE block)?
       eEND

--- a/nelua/syntaxdefs.lua
+++ b/nelua/syntaxdefs.lua
@@ -349,7 +349,7 @@ local function get_parser()
   ]], nil, true)
 
   grammar:add_group_peg('stat', 'switch', [[
-    ({} %SWITCH -> 'Switch' eexpr %DO
+    ({} %SWITCH -> 'Switch' eexpr %DO*
       {|(
         ({| %CASE eexpr (%COMMA expr)* eTHEN block |})+ / %{ExpectedCase})
       |}

--- a/spec/02-syntaxdefs_spec.lua
+++ b/spec/02-syntaxdefs_spec.lua
@@ -656,7 +656,7 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {{n.Id{'b'}}, n.Block{{}}} }
+          { {n.Id{'b'}, n.Block{{}}} }
     }}})
   end)
   it("with else part", function()
@@ -664,7 +664,7 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {{n.Id{'b'}}, n.Block{{}}} },
+          { {n.Id{'b'}, n.Block{{}}} },
           n.Block{{}}
     }}})
   end)
@@ -673,8 +673,8 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {{n.Id{'b'}}, n.Block{{}}},
-            {{n.Id{'c'}}, n.Block{{}}}
+          { {n.Id{'b'}, n.Block{{}}},
+            {n.Id{'c'}, n.Block{{}}}
           },
           n.Block{{}}
     }}})
@@ -684,7 +684,7 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {{n.Id{'b'}, n.Id{'c'}}, n.Block{{}}} },
+          { {n.Id{'b'}, n.Id{'c'}, n.Block{{}}} },
           n.Block{{}}
     }}})
   end)

--- a/spec/02-syntaxdefs_spec.lua
+++ b/spec/02-syntaxdefs_spec.lua
@@ -656,7 +656,7 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {n.Id{'b'}, n.Block{{}}} }
+          { {n.Id{{'b'}}, n.Block{{}}} }
     }}})
   end)
   it("with else part", function()
@@ -664,7 +664,7 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {n.Id{'b'}, n.Block{{}}} },
+          { {n.Id{{'b'}}, n.Block{{}}} },
           n.Block{{}}
     }}})
   end)
@@ -673,8 +673,8 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {n.Id{'b'}, n.Block{{}}},
-            {n.Id{'c'}, n.Block{{}}}
+          { {n.Id{{'b'}}, n.Block{{}}},
+            {n.Id{{'c'}}, n.Block{{}}}
           },
           n.Block{{}}
     }}})
@@ -684,7 +684,7 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {n.Id{'b'}, n.Id{'c'}, n.Block{{}}} },
+          { {n.Id{{'b', 'c'}}, n.Block{{}}} },
           n.Block{{}}
     }}})
   end)

--- a/spec/02-syntaxdefs_spec.lua
+++ b/spec/02-syntaxdefs_spec.lua
@@ -679,6 +679,15 @@ describe("statement switch", function()
           n.Block{{}}
     }}})
   end)
+  it("multiple cases with shared block", function()
+    assert.parse_ast(nelua_parser, "switch a do case b, c then then else end",
+      n.Block{{
+        n.Switch{
+          n.Id{'a'},
+          { {n.Id{'b'}, n.Id{'c'}, n.Block{{}}} },
+          n.Block{{}}
+    }}})
+  end)
 end)
 
 --------------------------------------------------------------------------------

--- a/spec/02-syntaxdefs_spec.lua
+++ b/spec/02-syntaxdefs_spec.lua
@@ -656,7 +656,7 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {n.Id{'b'}, n.Block{{}}} }
+          { {{n.Id{'b'}}, n.Block{{}}} }
     }}})
   end)
   it("with else part", function()
@@ -664,7 +664,7 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {n.Id{'b'}, n.Block{{}}} },
+          { {{n.Id{'b'}}, n.Block{{}}} },
           n.Block{{}}
     }}})
   end)
@@ -673,8 +673,8 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {n.Id{'b'}, n.Block{{}}},
-            {n.Id{'c'}, n.Block{{}}}
+          { {{n.Id{'b'}}, n.Block{{}}},
+            {{n.Id{'c'}}, n.Block{{}}}
           },
           n.Block{{}}
     }}})
@@ -684,7 +684,7 @@ describe("statement switch", function()
       n.Block{{
         n.Switch{
           n.Id{'a'},
-          { {n.Id{'b'}, n.Id{'c'}, n.Block{{}}} },
+          { {{n.Id{'b'}, n.Id{'c'}}, n.Block{{}}} },
           n.Block{{}}
     }}})
   end)

--- a/spec/02-syntaxdefs_spec.lua
+++ b/spec/02-syntaxdefs_spec.lua
@@ -680,7 +680,7 @@ describe("statement switch", function()
     }}})
   end)
   it("multiple cases with shared block", function()
-    assert.parse_ast(nelua_parser, "switch a do case b, c then then else end",
+    assert.parse_ast(nelua_parser, "switch a do case b, c then else end",
       n.Block{{
         n.Switch{
           n.Id{'a'},

--- a/spec/03-typechecker_spec.lua
+++ b/spec/03-typechecker_spec.lua
@@ -637,6 +637,7 @@ it("function return", function()
     local function f(): integer if true then return 1 else return 2 end end
     local function f(): integer do return 1 end end
     local function f(): integer switch 1 case 1 then return 1 else return 2 end end
+    local function f(): integer switch 1 case 1, 2 then return 1 else return 2 end end
   ]])
   assert.analyze_error([[
     local function f() end

--- a/spec/05-cgenerator_spec.lua
+++ b/spec/05-cgenerator_spec.lua
@@ -178,13 +178,15 @@ it("if", function()
 end)
 
 it("switch", function()
-  assert.generate_c("local a,f,g,h; do switch a case 1 then f() case 2 then g() else h() end end",[[
+  assert.generate_c("local a,f,g,h; do switch a do case 1 then f() case 2, 3, 4 then g() else h() end end",[[
     switch(a) {
       case 1: {
         f();
         break;
       }
-      case 2: {
+      case 2:
+      case 3:
+      case 4: {
         g();
         break;
       }


### PR DESCRIPTION
```
local a = 1
switch a do
	case 2, 1 then
		print '2 or 1'
	case 3 then
		print("3")
	else
		print("none of them")
end
```