### PR TITLE
Fix running `make test` on macOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,7 @@ else ifeq ($(SYS), Windows)
 	EXE=nelua-lua.exe
 else ifeq ($(SYS), Darwin)
 	CC=clang
-	LDFLAGS=
+	LDFLAGS=-rdynamic
 	DEFS+=-DLUA_USE_MACOSX
 else # probably POSIX
 	CC=cc


### PR DESCRIPTION
In ea1263abc057da4bcb49c4dff8392304facbc0e7 I set `LDFLAGS` to nothing on macOS because LLVM's linker doesn't support the `-E` flag. However, as I've learned, it turns out that flag is essential: it instructs the linker to export all symbols, even if they aren't used.

Without this flag, running `make test` will fail because the `lua-term` LuaRock is [trying to to call the Lua C API](https://github.com/hoelzro/lua-term/blob/375fa065/core.c#L13) but can't find it - it's been stripped out of the symbol table by the linker. This is the source of the [original error I was getting](https://github.com/edubart/nelua-lang/pull/22#issuecomment-684140535) when running `make test`.

On macOS, `-rdynamic` seems to do the same thing as `-E`:

> This instructs the linker to add all symbols, not only used ones, to the dynamic symbol table.

By applying this patch, you can now run `make test` on macOS using `nelua-lua`:

~~~sh
$ make test
make[1]: Nothing to be done for `default'.
busted --lua=src/nelua-lua
●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●✱●●●●●●●
424 successes / 0 failures / 1 error / 0 pending : 4.866005 seconds

Error → spec/08-runner_spec.lua @ 16
Nelua runner should run simple programs
./spec/tools/assert.lua:159: expected success status in run:
C compilation for 'nelua_cache/spec/eval_frsSPfEvbaL' failed:
ld: unknown option: --as-needed
clang: error: linker command failed with exit code 1 (use -v to see invocation)

stack traceback:
	./nelua/utils/errorer.lua:14: in function 'nelua.utils.errorer.assertf'
	./spec/tools/assert.lua:159: in function 'luassert.run'
	spec/08-runner_spec.lua:24: in function <spec/08-runner_spec.lua:16>

make: *** [test] Error 1
~~~

Thanks for your patience as I slowly figured this out! Is there anything else I should test to make sure everything is working properly? 
