### PR TITLE
add missing timespec_t typedef on lib/C/time.nelua

### DIFF
--- a/lib/C/time.nelua
+++ b/lib/C/time.nelua
@@ -3,6 +3,7 @@ cinclude '<time.h>'
 
 cemitdecl([==[
 typedef struct tm tm_t;
+typedef struct timespec timespec_t;
 ]==])
 
 local neluatypes = require 'nelua.types'


### PR DESCRIPTION
Considering this code:
```lua
require 'C.stdio'
require 'C.time'
require 'span'

-- cimports from lib/C/time.nelua
## local neluatypes = require 'nelua.types'
local TIME_UTC: cint <cimport, nodecl>;
local time_t <cimport'time_t',nodecl> = #[neluatypes.IntegralType('time_t', primtypes.clong.size)]#
local timespec <cimport'timespec_t',nodecl> = @record {
  tv_sec: time_t,
  tv_nsec: clong
}

local ts: timespec;
C.timespec_get(&ts, TIME_UTC)
local buff: [100]byte;
local sbuff: span(byte) = &buff
C.strftime(&buff[0], #buff, "%D %T", C.gmtime(&ts.tv_sec))
C.printf("Current time: %s.%09ld UTC\n", sbuff.data, ts.tv_nsec)

-- original code: https://en.cppreference.com/w/c/chrono/timespec_get
--
-- #include <stdio.h>
-- #include <time.h>
--
-- int main(void)
-- {
--     struct timespec ts;
--     timespec_get(&ts, TIME_UTC);
--     char buff[100];
--     strftime(buff, sizeof buff, "%D %T", gmtime(&ts.tv_sec));
--     printf("Current time: %s.%09ld UTC\n", buff, ts.tv_nsec);
-- }
```
GCC was triggering this message:
```
$ nelua teste.nelua 
generated nelua_cache/teste.c
gcc -o "nelua_cache/teste" "nelua_cache/teste.c" -Wall -lm -fwrapv -g
C compilation for 'nelua_cache/teste' failed:
nelua_cache/teste.c:41:9: error: unknown type name ‘timespec_t’
   41 | typedef timespec_t* timespec_t_ptr;
      |         ^~~~~~~~~~
nelua_cache/teste.c:77:8: error: unknown type name ‘timespec_t’
   77 | static timespec_t teste_ts = {0};
      |        ^~~~~~~~~~
nelua_cache/teste.c: In function ‘nelua_main’:
nelua_cache/teste.c:111:76: error: request for member ‘tv_sec’ in something not a structure or union
  111 |   strftime((char*)(&teste_buff.data[0]), 100U, __strlit2, gmtime((&teste_ts.tv_sec)));
      |                                                                            ^
nelua_cache/teste.c:112:47: error: request for member ‘tv_nsec’ in something not a structure or union
  112 |   printf(__strlit3, teste_sbuff.data, teste_ts.tv_nsec);
      |                                               ^
```
This problem was caused because there was no timespec_t declared.
I noticed that there was a 
```lua
cemitdecl([==[
typedef struct tm tm_t;
]==])
```
So, I added a `typedef struct timespec timespec_t;`, which solves the problem:
```
$ nelua teste.nelua 
generated nelua_cache/teste.c
gcc -o "nelua_cache/teste" "nelua_cache/teste.c" -Wall -lm -fwrapv -g
/home/dreunix/Downloads/git/nelua-projs/nelua-raylib/nelua_cache/teste 
Current time: 09/21/20 22:55:07.862361753 UTC
```