### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/pages/overview.md
+++ b/docs/pages/overview.md
@@ -2289,10 +2289,10 @@ print(sum_container(&b)) -- outputs: 55
 
 ### Concept that infers to another type
 
-Sometimes is useful to infer a concept to a different type
+Sometimes it is useful to infer a concept to a different type
 from the incoming `attr`. For example, suppose you want to specialize a function
 that optionally accepts any kind of scalar, but you really want it to be implemented
-as an number:
+as a number:
 
 ```nelua
 local facultative_number_concept = #[concept(function(attr)
@@ -2302,7 +2302,7 @@ local facultative_number_concept = #[concept(function(attr)
     return true
   end
   -- instead of returning true, we return the desired type to be implemented,
-  -- the compiler will take care to implicit cast the incoming attr to the desired type,
+  -- the compiler will take care to implicitly cast the incoming attr to the desired type,
   -- or throw an error if not possible,
   -- here we want to force the function using this concept to implement as a 'number'
   return primtypes.number

--- a/docs/pages/tutorial.md
+++ b/docs/pages/tutorial.md
@@ -45,7 +45,7 @@ Now run again with:
 nelua --verbose examples/helloworld.nelua
 ```
 
-You will notice some messages of what the compiler doing,
+You will notice some messages of what the compiler is doing,
 and notice that it generated a file called `helloworld.c`.
 This is your program translated to C source code.
 If you know how to read C, I encourage you to open it and have a look.
@@ -66,7 +66,7 @@ Syntax definitions for the language are available for
 Sublime Text with [nelua-sublime](https://github.com/edubart/nelua-sublime).
 At the moment, only Sublime Text has a full definition, so I recommend giving it a try.
 If you use another code editor you can use Lua syntax highlighting,
-as it very similar (but of course, incomplete).
+as it is very similar (but of course, incomplete).
 
 I recommend using the syntax highlighter,
 as it makes the experience of playing around with the language more pleasant, since


### PR DESCRIPTION
Hey :wave: 

This PR fixes some small typos in the _Overview_ and _Tutorial_.