### PR TITLE
Fix install on custom $PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,9 @@ docs-gen:
 # Install
 
 # Install paths
+ifndef PREFIX
 PREFIX=/usr/local
+endif
 DPREFIX=$(DESTDIR)$(PREFIX)
 PREFIX_BIN=$(DPREFIX)/bin
 PREFIX_LIB=$(DPREFIX)/lib


### PR DESCRIPTION
### Motivation

Tried to install directly under $HOME/.local but $PREFIX wasn't respected.
So, to work as stated in https://nelua.io/installing/ I modified the Makefile.

### Code example

make
PREFIX=$HOME/.local make install
