### PR TITLE
Fix for #277 (incorrect line/col number)

### DIFF
--- a/lualib/nelua/thirdparty/lpegrex.lua
+++ b/lualib/nelua/thirdparty/lpegrex.lua
@@ -589,24 +589,16 @@ Returns line number, column number, line content, line start position and line e
 function lpegrex.calcline(subject, position)
   if position < 0 then error 'invalid position' end
   position = math.min(position, #subject)
-  local linestart = 0
-  local lastNewline = 0
-  while true do
-    local nextNewline = subject:find('\n', lastNewline + 1, true)
-    if not nextNewline or nextNewline > position then
-      break
-    end
-    linestart = lastNewline
-    lastNewline = nextNewline
+  local lastNewlinePatt = lpeg.P {lpeg.Cp() * ((1 - lpeg.P "\n") ^ 0 * "\n") ^ 0 * lpeg.Cp()}
+  local linestart = (lastNewlinePatt:match(subject:sub(1, position)) or 1) - 1
+  local linenum = select(2, subject:sub(1, position):gsub("\n", "\n")) + 1
+  if position > 0 and subject:sub(position, position) == "\n" then
+      linenum = linenum - 1
   end
-  local linenum = select(2, subject:sub(1, position):gsub('\n', '\n')) + 1
-  if position > 0 and subject:sub(position, position) == '\n' then
-    linenum = linenum - 1
-  end
-  local lineend = subject:find('\n', position + 1, true) or #subject + 1
+  local lineend = subject:find("\n", position + 1, true) or #subject + 1
   local line = subject:sub(linestart + 1, lineend - 1)
   local colnum = position - linestart
-  return linenum,colnum,line,linestart + 1,lineend
+  return linenum, colnum, line, linestart + 1, lineend
 end
 
 -- Auxiliary function for `prettyast`

--- a/lualib/nelua/thirdparty/lpegrex.lua
+++ b/lualib/nelua/thirdparty/lpegrex.lua
@@ -588,18 +588,16 @@ Returns line number, column number, line content, line start position and line e
 ]]
 function lpegrex.calcline(subject, position)
   if position < 0 then error 'invalid position' end
-  local sublen = #subject
-  if position > sublen then position = sublen end
+  position = math.min(position, #subject)
   local caps = calclinepatt:match(subject:sub(1,position))
-  local ncaps = #caps
-  local lineno = ncaps + 1
-  local lastpos = caps[ncaps] or 0
+  local lastpos = caps[#caps] or 0
   local linestart = lastpos + 1
-  local colno = position - lastpos
-  local lineend = subject:find("\n", position+1, true)
-  lineend = lineend and lineend-1 or #subject
-  local line = subject:sub(linestart, lineend)
-  return lineno, colno, line, linestart, lineend
+  local lineend = subject:find("\n", linestart, true) or #subject + 1
+  return #caps,                              -- line number 
+         position - lastpos > 0 and position - lastpos or position,  -- column number
+         subject:sub(linestart, lineend - 1), -- line content
+         linestart,                           -- line start pos
+         lineend                             -- line end pos
 end
 
 -- Auxiliary function for `prettyast`

--- a/lualib/nelua/thirdparty/lpegrex.lua
+++ b/lualib/nelua/thirdparty/lpegrex.lua
@@ -593,7 +593,8 @@ function lpegrex.calcline(subject, position)
   local lastpos = caps[#caps] or 0
   local linestart = lastpos + 1
   local lineend = subject:find("\n", linestart, true) or #subject + 1
-  return #caps,                              -- line number 
+  
+  return #caps + 1,                          -- line number
          position - lastpos > 0 and position - lastpos or position,  -- column number
          subject:sub(linestart, lineend - 1), -- line content
          linestart,                           -- line start pos

--- a/lualib/nelua/thirdparty/lpegrex.lua
+++ b/lualib/nelua/thirdparty/lpegrex.lua
@@ -589,16 +589,24 @@ Returns line number, column number, line content, line start position and line e
 function lpegrex.calcline(subject, position)
   if position < 0 then error 'invalid position' end
   position = math.min(position, #subject)
-  local caps = calclinepatt:match(subject:sub(1,position))
-  local lastpos = caps[#caps] or 0
-  local linestart = lastpos + 1
-  local lineend = subject:find("\n", linestart, true) or #subject + 1
-  
-  return #caps + 1,                          -- line number
-         position - lastpos > 0 and position - lastpos or position,  -- column number
-         subject:sub(linestart, lineend - 1), -- line content
-         linestart,                           -- line start pos
-         lineend                             -- line end pos
+  local linestart = 0
+  local lastNewline = 0
+  while true do
+    local nextNewline = subject:find('\n', lastNewline + 1, true)
+    if not nextNewline or nextNewline > position then
+      break
+    end
+    linestart = lastNewline
+    lastNewline = nextNewline
+  end
+  local linenum = select(2, subject:sub(1, position):gsub('\n', '\n')) + 1
+  if position > 0 and subject:sub(position, position) == '\n' then
+    linenum = linenum - 1
+  end
+  local lineend = subject:find('\n', position + 1, true) or #subject + 1
+  local line = subject:sub(linestart + 1, lineend - 1)
+  local colnum = position - linestart
+  return linenum,colnum,line,linestart + 1,lineend
 end
 
 -- Auxiliary function for `prettyast`

--- a/spec/aster_spec.lua
+++ b/spec/aster_spec.lua
@@ -2,6 +2,7 @@ local lester = require 'nelua.thirdparty.lester'
 local aster = require 'nelua.aster'
 local expect = require 'spec.tools.expect'
 local Attr = require 'nelua.attr'
+local lpegrex = require 'nelua.thirdparty.lpegrex'
 local describe, it = lester.describe, lester.it
 
 local n = aster
@@ -60,6 +61,14 @@ end)
 it("clone", function()
   expect.equal(aster.pretty(aster.clone(n.Id{'x'})), aster.pretty(n.Id{'x'}))
   expect.equal(aster.pretty(aster.clone{n.Id{'x'},n.Number{1}}), aster.pretty{n.Id{'x'},n.Number{1}})
+end)
+
+it("error on line numbers", function()
+  expect.fail(function() 
+    aster.parse([[print(]])
+  end, "unclosed parenthesis, did you forget a `)`?")
+  local lineno, colno = lpegrex.calcline("print(", 6)
+  assert(lineno == 1 and colno == 6, "expected error at line 1, column 6")
 end)
 
 end)


### PR DESCRIPTION
Fix `lpegrex.calcline` to Correctly Compute Line and Column Numbers

**Functionality Changes:**
- **Position Capping:** Ensured that the `position` does not exceed the length of `subject` by using `math.min(position, #subject)` instead of an `if` statement. This prevents potential out-of-bounds errors.
- **Column Number Calculation:** Updated the logic to accurately calculate the column number. If the calculated `colno` is `0`, it now correctly assigns `position` as the column number, ensuring accurate reporting at line boundaries.
- **Line End Handling:** Improved the determination of `lineend` by providing a fallback to `#subject + 1` when a newline character is not found. This ensures the entire line is captured correctly, especially for the last line in the `subject`.

**Issue:**
Fixes #277 - Incorrect line and line number for syntax error.

**WARNING: Please, read this note carefully before submitting a new pull request:**

Nelua is open source,
but not very open to contributions in the form of pull requests,
if you would like something fixed or implemented in the core language
try first submitting a bug report or opening a discussion instead of doing a PR.
The authors prefer it this way, so that the ideal solution is always provided,
without unwanted consequences on the project, thus keeping the quality of the software.

If you insist doing a PR, typically for a small bug fix, then follow these guidelines:

- Make sure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
- Don't send big pull requests (lots of changes), they are difficult to review. It's better to send small pull requests, one at a time.
- Use different pull requests for different issues, each pull request should only address one issue.
- When fixing a bug or adding a feature add tests related to your changes to assure the changes will always work as intended in the future and also to cover new lines added.
- Verify that changes don't break the tests, you can check this with `make test`.
- Follow the same coding style rules as the code base.
- Pull requests just doing style changes are not welcome, a PR must address a real issue.

### Motivation

Current version has a very subtle difference in the line number, so its more clear.

### Code example

`print(`

Expected behavior

```
nelua test.nelua
test.nelua:1:6: syntax error: unclosed parenthesis, did you forget a `)`?

^
```

