### PR TITLE
Add compiler phase benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,10 @@ test: $(NELUALUA)
 test-quick: $(NELUALUA)
 	@LESTER_QUIET=true LESTER_STOP_ON_FAIL=true $(LUA) spec/init.lua
 
+# Benchmark compiler phases in isolated processes.
+benchmark-compiler: $(NELUALUA)
+	$(LUA) -lnelua nelua.lua --script spec/tools/compilerbench.lua $(BENCHARGS)
+
 # Run lua static analysis using lua check.
 check:
 	@$(LUACHECK) -q .

--- a/spec/compilerbench_spec.lua
+++ b/spec/compilerbench_spec.lua
@@ -1,0 +1,170 @@
+local lester = require 'nelua.thirdparty.lester'
+local describe, it = lester.describe, lester.it
+
+local expect = lester.expect
+local compilerbench = require 'spec.tools.compilerbench'
+local fs = require 'nelua.utils.fs'
+
+local function temp_path(suffix)
+  local path = fs.tmpname()
+  fs.deletefile(path)
+  return path..(suffix or '')
+end
+
+local function with_temp_source(code, callback)
+  local path = temp_path('.nelua')
+  assert(fs.writefile(path, code))
+  local ok, err = xpcall(function()
+    callback(path)
+  end, debug.traceback)
+  fs.deletefile(path)
+  assert(ok, err)
+end
+
+local function capture_print(callback)
+  local lines = {}
+  local oldprint = _G.print
+  _G.print = function(...)
+    local values = {}
+    for i=1,select('#', ...) do
+      values[i] = tostring(select(i, ...))
+    end
+    lines[#lines+1] = table.concat(values, '\t')
+  end
+  local ok, err = xpcall(callback, debug.traceback)
+  _G.print = oldprint
+  assert(ok, err)
+  return table.concat(lines, '\n')
+end
+
+local function count_plain(text, substring)
+  local count, start = 0, 1
+  while true do
+    local pos = text:find(substring, start, true)
+    if not pos then return count end
+    count = count + 1
+    start = pos + #substring
+  end
+end
+
+describe("compiler benchmark", function()
+
+it("parse compiler timing output", function()
+  local timings = compilerbench.parse_timing([[
+startup      1.5 ms
+parse        2.0 ms
+preprocess   0.5 ms
+analyze      3.0 ms
+generate     4.0 ms
+total time   11.0 ms
+]])
+  expect.equal(1.5, timings.startup)
+  expect.equal(2.0, timings.parse)
+  expect.equal(0.5, timings.preprocess)
+  expect.equal(3.0, timings.analyze)
+  expect.equal(4.0, timings.generate)
+  expect.equal(11.0, timings.total)
+end)
+
+it("calculate timing medians without modifying samples", function()
+  local samples = {4, 1, 3, 2}
+  expect.equal(2.5, compilerbench.median(samples))
+  expect.equal(4, samples[1])
+  expect.equal(1, samples[2])
+  expect.equal(3, samples[3])
+  expect.equal(2, samples[4])
+  expect.equal(2, compilerbench.median({3, 1, 2}))
+end)
+
+it("validate repetition count", function()
+  expect.equal(5, compilerbench.parse_runs(nil))
+  expect.equal(7, compilerbench.parse_runs('7'))
+  local ok, err = pcall(compilerbench.parse_runs, '0')
+  assert(not ok and tostring(err):find('positive integer', 1, true), err)
+  ok, err = pcall(compilerbench.parse_runs, '2.5')
+  assert(not ok and tostring(err):find('positive integer', 1, true), err)
+end)
+
+it("discard warmup timing samples", function()
+  local calls = 0
+  local samples = compilerbench.collect(2, function()
+    calls = calls + 1
+    return {
+      startup = calls,
+      parse = calls + 1,
+      preprocess = calls + 2,
+      analyze = calls + 3,
+      generate = calls + 4,
+      total = calls + 5,
+    }
+  end)
+  expect.equal(3, calls)
+  expect.equal(2, samples.startup[1])
+  expect.equal(3, samples.startup[2])
+  expect.equal(7, samples.total[1])
+  expect.equal(8, samples.total[2])
+end)
+
+it("reject incomplete timing samples", function()
+  local ok, err = pcall(compilerbench.collect, 1, function()
+    return {startup = 1}
+  end)
+  assert(not ok and tostring(err):find("missing timing phase 'parse'", 1, true), err)
+end)
+
+it("default to the upstream compiler workload", function()
+  local inputs = compilerbench.resolve_inputs({})
+  expect.equal(1, #inputs)
+  expect.equal('tests/all_test.nelua', inputs[1])
+end)
+
+it("preserve explicit benchmark inputs", function()
+  local args = {'first.nelua', 'second.nelua'}
+  local inputs = compilerbench.resolve_inputs(args)
+  assert(inputs ~= args)
+  expect.equal(2, #inputs)
+  expect.equal('first.nelua', inputs[1])
+  expect.equal('second.nelua', inputs[2])
+end)
+
+it("measure a real compiler input and clean generated files", function()
+  with_temp_source('local x: integer = 1\n', function(input)
+    local outprefix = temp_path()
+    assert(fs.writefile(outprefix, 'sentinel'))
+    local timings = compilerbench.measure_input(input, outprefix)
+    for _,phase in ipairs({'startup', 'parse', 'preprocess', 'analyze', 'generate', 'total'}) do
+      assert(type(timings[phase]) == 'number', "missing timing phase '"..phase.."'")
+    end
+    assert(not fs.isfile(outprefix), 'temporary output file was not removed')
+    assert(not fs.isfile(outprefix..'.c'), 'temporary C file was not removed')
+  end)
+end)
+
+it("clean generated files after a compiler error", function()
+  with_temp_source('local =\n', function(input)
+    local outprefix = temp_path()
+    assert(fs.writefile(outprefix, 'sentinel'))
+    assert(fs.writefile(outprefix..'.c', 'sentinel'))
+    local ok = pcall(compilerbench.measure_input, input, outprefix)
+    assert(not ok, 'invalid source unexpectedly compiled')
+    assert(not fs.isfile(outprefix), 'temporary output file was not removed')
+    assert(not fs.isfile(outprefix..'.c'), 'temporary C file was not removed')
+  end)
+end)
+
+it("report every phase for multiple real inputs", function()
+  with_temp_source('local x: integer = 1\n', function(first)
+    with_temp_source('local y: integer = 2\n', function(second)
+      local output = capture_print(function()
+        expect.equal(0, compilerbench.main({first, second}, 1))
+      end)
+      expect.equal(6, count_plain(output, first))
+      expect.equal(6, count_plain(output, second))
+      for _,phase in ipairs({'startup', 'parse', 'preprocess', 'analyze', 'generate', 'total'}) do
+        expect.equal(2, count_plain(output, phase))
+      end
+    end)
+  end)
+end)
+
+end)

--- a/spec/init.lua
+++ b/spec/init.lua
@@ -17,6 +17,7 @@ require 'spec.cgenerator_spec'
 require 'spec.preprocessor_spec'
 require 'spec.stdlib_spec'
 require 'spec.runner_spec'
+require 'spec.compilerbench_spec'
 
 lester.report()
 lester.exit()

--- a/spec/tools/compilerbench.lua
+++ b/spec/tools/compilerbench.lua
@@ -1,0 +1,135 @@
+--[[
+Compiler benchmark utility.
+
+Runs the compiler in fresh processes and summarizes its existing timing output.
+This is intended for comparing compiler changes, not generated program speed.
+Use NELUA_BENCH_RUNS to change repetitions and pass source files as arguments.
+]]
+
+local executor = require 'nelua.utils.executor'
+local fs = require 'nelua.utils.fs'
+local platform = require 'nelua.utils.platform'
+
+local compilerbench = {}
+local nelua = platform.is_windows and 'nelua.bat' or './nelua'
+
+local phase_order = {
+  'startup',
+  'parse',
+  'preprocess',
+  'analyze',
+  'generate',
+  'total',
+}
+
+-- Parse the output produced by the compiler's `--timing` option.
+function compilerbench.parse_timing(output)
+  local timings = {}
+  for name,value in output:gmatch('([%a ]-)%s+([%d.]+)%s+ms') do
+    name = name:match('^%s*(.-)%s*$')
+    if name == 'total time' then
+      name = 'total'
+    end
+    timings[name] = tonumber(value)
+  end
+  return timings
+end
+
+-- Return the median without modifying the input list.
+function compilerbench.median(values)
+  assert(#values > 0, 'cannot calculate median of an empty list')
+  local sorted = {}
+  for i,value in ipairs(values) do
+    sorted[i] = value
+  end
+  table.sort(sorted)
+  local middle = math.floor(#sorted / 2) + 1
+  if #sorted % 2 == 1 then
+    return sorted[middle]
+  end
+  return (sorted[middle-1] + sorted[middle]) / 2
+end
+
+-- Parse the number of measured runs, defaulting to five.
+function compilerbench.parse_runs(value)
+  local runs = value == nil and 5 or tonumber(value)
+  assert(runs and runs >= 1 and runs == math.floor(runs),
+    'NELUA_BENCH_RUNS must be a positive integer')
+  return runs
+end
+
+-- Copy explicit inputs or select the upstream compiler workload.
+function compilerbench.resolve_inputs(args)
+  local inputs = {}
+  for i,input in ipairs(args) do
+    inputs[i] = input
+  end
+  if #inputs == 0 then
+    inputs[1] = 'tests/all_test.nelua'
+  end
+  return inputs
+end
+
+-- Collect one warmup followed by `runs` complete timing samples.
+function compilerbench.collect(runs, measure)
+  local samples = {}
+  for _,phase in ipairs(phase_order) do
+    samples[phase] = {}
+  end
+
+  for run=0,runs do
+    local timings = measure(run)
+    if run > 0 then
+      for _,phase in ipairs(phase_order) do
+        local value = timings[phase]
+        assert(type(value) == 'number', string.format("missing timing phase '%s'", phase))
+        samples[phase][run] = value
+      end
+    end
+  end
+  return samples
+end
+
+--luacov:disable
+
+-- Measure one input in a fresh compiler process and remove generated files.
+function compilerbench.measure_input(input, outprefix)
+  outprefix = outprefix or fs.tmpname()
+  local output, err = executor.evalex(nelua, {
+    '--no-color', '--no-cache', '--timing', '--code', '--output', outprefix, input
+  })
+  fs.deletefile(outprefix)
+  fs.deletefile(outprefix..'.c')
+  assert(output, err)
+  return compilerbench.parse_timing(output)
+end
+
+local function report_input(input, samples)
+  for _,phase in ipairs(phase_order) do
+    print(string.format('%-28s %-12s %10.1f',
+      input, phase, compilerbench.median(samples[phase])))
+  end
+end
+
+function compilerbench.main(args, runs)
+  runs = runs or compilerbench.parse_runs(os.getenv('NELUA_BENCH_RUNS'))
+  local inputs = compilerbench.resolve_inputs(args)
+
+  print(string.format('%-28s %-12s %10s', 'input', 'phase', 'median ms'))
+  print(string.rep('-', 52))
+  for _,input in ipairs(inputs) do
+    local samples = compilerbench.collect(runs, function()
+      return compilerbench.measure_input(input)
+    end)
+    report_input(input, samples)
+  end
+  return 0
+end
+
+if not ... then
+  os.exit(compilerbench.main(arg))
+end
+
+--luacov:enable
+
+return compilerbench


### PR DESCRIPTION
## Verification

The final matrix passed:

- supported OS/compiler matrix
- 32-bit build and tests
- coverage, lint, benchmark invocations, and sanitizers 

The last failure was real rather than decorative: Windows rejected `./nelua.bat`. The Make target now invokes the bundled Lua compiler directly, matching the batch wrapper’s actual behavior without changing global launcher semantics.